### PR TITLE
wrong named props mui5 fix

### DIFF
--- a/src/components/TablePagination.js
+++ b/src/components/TablePagination.js
@@ -98,8 +98,8 @@ function TablePagination(props) {
                 },
               }}
               rowsPerPageOptions={options.rowsPerPageOptions}
-              onChangePage={handlePageChange}
-              onChangeRowsPerPage={handleRowChange}
+              onPageChange={handlePageChange}
+              onRowsPerPageChange={handleRowChange}
             />
           </div>
         </MuiTableCell>

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -354,7 +354,7 @@ class TableToolbar extends React.Component {
               <IconButton
                 aria-label={search}
                 data-testid={search + '-iconButton'}
-                buttonref={el => (this.searchButton = el)}
+                buttonRef={el => (this.searchButton = el)}
                 classes={{ root: this.getActiveIcon(classes, 'search') }}
                 disabled={options.search === 'disabled'}
                 onClick={this.handleSearchIconClick}>

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -354,7 +354,7 @@ class TableToolbar extends React.Component {
               <IconButton
                 aria-label={search}
                 data-testid={search + '-iconButton'}
-                buttonRef={el => (this.searchButton = el)}
+                buttonref={el => (this.searchButton = el)}
                 classes={{ root: this.getActiveIcon(classes, 'search') }}
                 disabled={options.search === 'disabled'}
                 onClick={this.handleSearchIconClick}>


### PR DESCRIPTION
This is the error from earlier fixed when pagination and rows per page would not work.

https://github.com/mui-org/material-ui/commit/ab33be89a2da86b3f28c43d08f29697c85e80151#diff-a88e6d0575e76796d2fdea671ed8b3620762fbd4e4cdcfc01677fc4f3be6fadb

![image](https://user-images.githubusercontent.com/22813220/135300828-26c4ad05-070f-426a-9dcb-fc0b43f6b923.png)
