### PR TITLE
Fixed the issue with the variant of sort button.

### DIFF
--- a/src/components/TableFilter.js
+++ b/src/components/TableFilter.js
@@ -221,7 +221,7 @@ class TableFilter extends React.Component {
         key={index}
         xs={width}
         classes={{ 'grid-xs-12': classes.gridListTile, 'grid-xs-6': classes.gridListTile }}>
-        <FormControl key={index} fullWidth>
+        <FormControl key={index} variant={'standard'} fullWidth>
           <InputLabel htmlFor={column.name}>{column.label}</InputLabel>
           <Select
             fullWidth
@@ -260,6 +260,7 @@ class TableFilter extends React.Component {
         <FormControl key={index} fullWidth>
           <TextField
             fullWidth
+            variant={'standard'}
             label={column.label}
             value={filterList[index].toString() || ''}
             data-testid={'filtertextfield-' + column.name}
@@ -284,7 +285,7 @@ class TableFilter extends React.Component {
         key={index}
         xs={width}
         classes={{ 'grid-xs-12': classes.gridListTile, 'grid-xs-6': classes.gridListTile }}>
-        <FormControl key={index} fullWidth>
+        <FormControl key={index} variant={'standard'} fullWidth>
           <InputLabel htmlFor={column.name}>{column.label}</InputLabel>
           <Select
             multiple

--- a/src/components/TableHeadCell.js
+++ b/src/components/TableHeadCell.js
@@ -48,6 +48,8 @@ const useStyles = makeStyles(
       marginLeft: '-8px',
       minWidth: 0,
       marginRight: '8px',
+      paddingLeft: '8px',
+      paddingRight: '8px',
     },
     contentWrapper: {
       display: 'flex',

--- a/src/components/TableHeadCell.js
+++ b/src/components/TableHeadCell.js
@@ -215,7 +215,7 @@ const TableHeadCell = ({
               popper: classes.mypopper,
             }}>
             <Button
-              variant="text"
+              variant=""
               onKeyUp={handleKeyboardSortInput}
               onClick={handleSortClick}
               className={classes.toolButton}

--- a/src/components/TableSearch.js
+++ b/src/components/TableSearch.js
@@ -11,10 +11,10 @@ const useStyles = makeStyles(
     main: {
       display: 'flex',
       flex: '1 0 auto',
+      alignItems: "center"
     },
     searchIcon: {
       color: theme.palette.text.secondary,
-      marginTop: '10px',
       marginRight: '8px',
     },
     searchText: {

--- a/src/components/TableSearch.js
+++ b/src/components/TableSearch.js
@@ -51,6 +51,7 @@ const TableSearch = ({ options, searchText, onSearch, onHide }) => {
         <TextField
           className={classes.searchText}
           autoFocus={true}
+          variant={'standard'}
           InputProps={{
             'data-test-id': options.textLabels.toolbar.search,
           }}

--- a/src/plug-ins/DebounceSearchRender.js
+++ b/src/plug-ins/DebounceSearchRender.js
@@ -26,10 +26,10 @@ const defaultStyles = theme => ({
   main: {
     display: 'flex',
     flex: '1 0 auto',
+    alignItems: "center"
   },
   searchIcon: {
     color: theme.palette.text.secondary,
-    marginTop: '10px',
     marginRight: '8px',
   },
   searchText: {

--- a/src/plug-ins/DebounceSearchRender.js
+++ b/src/plug-ins/DebounceSearchRender.js
@@ -75,6 +75,7 @@ class _DebounceTableSearch extends React.Component {
         <div className={classes.main}>
           <SearchIcon className={classes.searchIcon} />
           <TextField
+            variant={'standard'}
             className={classes.searchText}
             autoFocus={true}
             InputProps={{


### PR DESCRIPTION
Hey @zxhmike, Awesome work buddy.
In mui5, by default, the button is taking the **primary colour** rather than **no colour** like mui4. 
Due to that, the sort button in the table is using the primary variant rather than the default variant. So fixed the issue with the variant of the button. 
Present: 
![image](https://user-images.githubusercontent.com/20638539/137074527-780f5cc6-531d-4c54-b15a-e9bba784dc4f.png)
Expected: 
![image](https://user-images.githubusercontent.com/20638539/137074584-ae24cbcf-8640-46b2-9920-53287cebceb5.png)
