### PR TITLE
Updated the theme breakpoint down by one step

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -57,7 +57,7 @@ const defaultTableStyles = theme => ({
   // deprecated, but continuing support through v3.x
   responsiveStacked: {
     overflow: 'auto',
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('md')]: {
       overflow: 'hidden',
     },
   },

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -16,14 +16,14 @@ const defaultBodyStyles = theme => ({
     textAlign: 'center',
   },
   lastStackedCell: {
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('md')]: {
       '& td:last-child': {
         borderBottom: 'none',
       },
     },
   },
   lastSimpleCell: {
-    [theme.breakpoints.down('xs')]: {
+    [theme.breakpoints.down('sm')]: {
       '& td:last-child': {
         borderBottom: 'none',
       },

--- a/src/components/TableBodyCell.js
+++ b/src/components/TableBodyCell.js
@@ -10,7 +10,7 @@ const useStyles = makeStyles(
       display: 'none',
     },
     simpleHeader: {
-      [theme.breakpoints.down('xs')]: {
+      [theme.breakpoints.down('sm')]: {
         display: 'inline-block',
         fontWeight: 'bold',
         width: '100%',
@@ -18,7 +18,7 @@ const useStyles = makeStyles(
       },
     },
     simpleCell: {
-      [theme.breakpoints.down('xs')]: {
+      [theme.breakpoints.down('sm')]: {
         display: 'inline-block',
         width: '100%',
         boxSizing: 'border-box',
@@ -28,7 +28,7 @@ const useStyles = makeStyles(
       verticalAlign: 'top',
     },
     stackedCommon: {
-      [theme.breakpoints.down('sm')]: {
+      [theme.breakpoints.down('md')]: {
         display: 'inline-block',
         fontSize: '16px',
         height: 'auto',
@@ -56,7 +56,7 @@ const useStyles = makeStyles(
       },
     },
     stackedParent: {
-      [theme.breakpoints.down('sm')]: {
+      [theme.breakpoints.down('md')]: {
         display: 'inline-block',
         fontSize: '16px',
         height: 'auto',
@@ -72,19 +72,19 @@ const useStyles = makeStyles(
       boxSizing: 'border-box',
     },
     cellStackedSmall: {
-      [theme.breakpoints.down('sm')]: {
+      [theme.breakpoints.down('md')]: {
         width: '50%',
         boxSizing: 'border-box',
       },
     },
     responsiveStackedSmall: {
-      [theme.breakpoints.down('sm')]: {
+      [theme.breakpoints.down('md')]: {
         width: '50%',
         boxSizing: 'border-box',
       },
     },
     responsiveStackedSmallParent: {
-      [theme.breakpoints.down('sm')]: {
+      [theme.breakpoints.down('md')]: {
         width: '100%',
         boxSizing: 'border-box',
       },

--- a/src/components/TableBodyRow.js
+++ b/src/components/TableBodyRow.js
@@ -18,7 +18,7 @@ const defaultBodyRowStyles = theme => ({
   },
   hoverCursor: { cursor: 'pointer' },
   responsiveStacked: {
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('md')]: {
       borderTop: 'solid 2px rgba(0, 0, 0, 0.15)',
       borderBottom: 'solid 2px rgba(0, 0, 0, 0.15)',
       padding: 0,
@@ -26,7 +26,7 @@ const defaultBodyRowStyles = theme => ({
     },
   },
   responsiveSimple: {
-    [theme.breakpoints.down('xs')]: {
+    [theme.breakpoints.down('sm')]: {
       borderTop: 'solid 2px rgba(0, 0, 0, 0.15)',
       borderBottom: 'solid 2px rgba(0, 0, 0, 0.15)',
       padding: 0,

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -10,7 +10,7 @@ const useStyles = makeStyles(
   theme => ({
     main: {},
     responsiveStacked: {
-      [theme.breakpoints.down('sm')]: {
+      [theme.breakpoints.down('md')]: {
         display: 'none',
       },
     },
@@ -18,7 +18,7 @@ const useStyles = makeStyles(
       display: 'none',
     },
     responsiveSimple: {
-      [theme.breakpoints.down('xs')]: {
+      [theme.breakpoints.down('sm')]: {
         display: 'none',
       },
     },

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -65,7 +65,7 @@ export const defaultToolbarStyles = theme => ({
     marginTop: '10px',
     marginRight: '8px',
   },
-  [theme.breakpoints.down('sm')]: {
+  [theme.breakpoints.down('md')]: {
     titleRoot: {},
     titleText: {
       fontSize: '16px',
@@ -82,7 +82,7 @@ export const defaultToolbarStyles = theme => ({
       textAlign: 'right',
     },
   },
-  [theme.breakpoints.down('xs')]: {
+  [theme.breakpoints.down('sm')]: {
     root: {
       display: 'block',
       '@media print': {


### PR DESCRIPTION
While migrating, we also had to increment the theme breakpoint down by one step as told [here](https://mui.com/guides/migration-v4/#theme). I think the codemod didn't deal with this thing.